### PR TITLE
feat: filter homelesshouseholds and update local state

### DIFF
--- a/web-client/src/graphql/__fixtures__/filters.ts
+++ b/web-client/src/graphql/__fixtures__/filters.ts
@@ -1,0 +1,9 @@
+export const filters = {
+  __typename: "Filters",
+  ageRange: [-Infinity, +Infinity],
+  decision: null,
+  ethnicity: null,
+  nationality: null,
+  need: null,
+  reason: null,
+}

--- a/web-client/src/graphql/__fixtures__/homelessHouseholds.ts
+++ b/web-client/src/graphql/__fixtures__/homelessHouseholds.ts
@@ -1,0 +1,35 @@
+export const homelessHouseholds = [
+  {
+    age: 31,
+    decision: "no priority need",
+    decisionCode: 3,
+    decisionDate: "2015-09-30T00:00:00.000Z",
+    ethnicity: "Other",
+    id: 7158,
+    nationality: "Not Rec",
+    need: "vulnerable - physical",
+    reason: "eviction - parents",
+  },
+  {
+    age: 47,
+    decision: "approved permanent rehous",
+    decisionCode: 1,
+    decisionDate: "2015-09-30T00:00:00.000Z",
+    ethnicity: "Black/BlkBrit: African",
+    id: 7159,
+    nationality: "Not Rec",
+    need: "dependent children",
+    reason: "end AST not arrears",
+  },
+  {
+    age: 27,
+    decision: "approved permanent rehous",
+    decisionCode: 1,
+    decisionDate: "2015-09-30T00:00:00.000Z",
+    ethnicity: "White: British",
+    id: 7161,
+    nationality: "Not Rec",
+    need: "dependent children",
+    reason: "DV - partner",
+  }
+];

--- a/web-client/src/graphql/resolvers.test.ts
+++ b/web-client/src/graphql/resolvers.test.ts
@@ -1,0 +1,63 @@
+import {
+  GET_FILTERS,
+  GET_HOMELESS_HOUSEHOLDS,
+} from '../queries';
+import { filters } from './__fixtures__/filters';
+import { homelessHouseholds } from './__fixtures__/homelessHouseholds'
+import { resolvers } from './resolvers';
+
+describe('resolvers', () => {
+  it('should updateFilter correctly', () => {
+    // arrange
+    const parent = {};
+    const args = {
+      input: {
+        filterName: "need",
+        filterValue: "vulnerable - physical"
+      }
+    };
+    const context = {
+      cache: {
+        readQuery: ({ query }: { query: any }) => {
+          if (query === GET_FILTERS) {
+            return { filters };
+          }
+          if (query === GET_HOMELESS_HOUSEHOLDS) {
+            return { homelessHouseholds };
+          }
+          return null;
+        },
+        writeQuery: jest.fn(),
+      }
+    }
+    // act
+    resolvers.Mutation.updateFilter(parent, args, context);
+    // assign
+    expect(context.cache.writeQuery).toHaveBeenCalledTimes(2);
+    expect(context.cache.writeQuery.mock.calls[0][0]).toMatchObject({
+      data: {
+        filters: {
+          ...filters,
+          need: "vulnerable - physical"
+        }
+      }
+    })
+    expect(context.cache.writeQuery.mock.calls[1][0]).toMatchObject({
+      data: {
+        filteredHomelessHouseholds: [
+          {
+            age: 31,
+            decision: "no priority need",
+            decisionCode: 3,
+            decisionDate: "2015-09-30T00:00:00.000Z",
+            ethnicity: "Other",
+            id: 7158,
+            nationality: "Not Rec",
+            need: "vulnerable - physical",
+            reason: "eviction - parents",
+          },
+        ]
+      }
+    })
+  })
+})

--- a/web-client/src/graphql/resolvers.ts
+++ b/web-client/src/graphql/resolvers.ts
@@ -1,6 +1,11 @@
-import { GET_FILTERS } from '../queries';
+import {
+  GET_FILTERED_HOMELESS_HOUSEHOLDS,
+  GET_FILTERS,
+  GET_HOMELESS_HOUSEHOLDS,
+} from '../queries';
 
 export const defaults = {
+  filteredHomelessHouseholds: [],
   filters: {
     __typename: "Filters",
     ageRange: [-Infinity, +Infinity],
@@ -25,23 +30,61 @@ interface IResolvers {
   Mutation: IMutation;
 }
 
+interface IFilterHomelessHouseholds {
+  homelessHouseholds: IHomelessHouseholds[];
+  filters: IFilters;
+}
+
+const createNullableFilter = (record: IHomelessHouseholds, filters: IFilters) => (filterAttribute: FilterAttribute): boolean => {
+  if (!filters[filterAttribute]) {
+    return true;
+  }
+  if (filterAttribute === 'ageRange') {
+    const age = record.age;
+    const [min, max] = filters.ageRange;
+    return (age >= min) && (age <= max);
+  }
+  return record[filterAttribute] === filters[filterAttribute];
+}
+
+export function filterHomelessHouseholds({ homelessHouseholds, filters }: IFilterHomelessHouseholds): IHomelessHouseholds[] {
+  return homelessHouseholds.filter(record => {
+    const nullableFilter = createNullableFilter(record, filters);
+    return (
+      nullableFilter('decision') &&
+      nullableFilter('need') &&
+      nullableFilter('reason') &&
+      nullableFilter('ageRange') &&
+      nullableFilter('ethnicity') &&
+      nullableFilter('nationality')
+    )
+  });
+}
 
 export const resolvers: IResolvers = {
   Mutation: {
-    updateFilter: (_, { input: { filterName, filterValue } }, { cache }) => {
-      const previousState = cache.readQuery({ query: GET_FILTERS });
-  
-      const data = {
+    updateFilter: (store, { input: { filterName, filterValue } }, { cache }) => {
+      const previousFilters = cache.readQuery({ query: GET_FILTERS });
+      const { homelessHouseholds } = cache.readQuery({ query: GET_HOMELESS_HOUSEHOLDS });
+
+      const nextFilters = {
         filters: {
-          ...previousState.filters,
+          ...previousFilters.filters,
           [filterName]: filterValue || null,
           __typename: 'Filters',
         }
       };
 
+      const filteredHomelessHouseholds = filterHomelessHouseholds({ homelessHouseholds, filters: nextFilters.filters });
+
       cache.writeQuery({
-        data,
+        data: nextFilters,
         query: GET_FILTERS,
+      });
+
+      cache.writeQuery({
+        data: { filteredHomelessHouseholds },
+        query: GET_FILTERED_HOMELESS_HOUSEHOLDS,
       });
 
       return true;

--- a/web-client/src/graphql/typedefs.ts
+++ b/web-client/src/graphql/typedefs.ts
@@ -33,8 +33,9 @@ export const typeDefs = `
   }
 
   type Query {
-    homelessHouseholds(input: HomelessHouseholdsInput!): [HomelessHouseholds]!
     filters: Filters!
+    filteredHomelessHouseholds: [HomelessHouseholds]!
+    homelessHouseholds(input: HomelessHouseholdsInput!): [HomelessHouseholds]!
   }
 
   type Mutation {

--- a/web-client/src/queries/index.ts
+++ b/web-client/src/queries/index.ts
@@ -2,7 +2,23 @@ import gql from 'graphql-tag';
 
 export const GET_HOMELESS_HOUSEHOLDS = gql`
   query HomelessHouseholds($input: HomelessHouseholdsInput!) {
-    homelessHouseholds(input: $input) {
+    homelessHouseholds(input: $input) @connection(key: "homelessHouseholds") {
+      id
+      age
+      decision
+      decisionCode
+      decisionDate
+      ethnicity
+      nationality
+      reason
+      need
+    }
+  }
+`
+
+export const GET_FILTERED_HOMELESS_HOUSEHOLDS = gql`
+  query {
+    filteredHomelessHouseholds @client {
       id
       age
       decision


### PR DESCRIPTION
Note that ```homelessHouseholds(input: $input) @connection(key: "homelessHouseholds")``` allows querying for homelessHouseholds without the problem of a stringified pagination key.